### PR TITLE
Update JAVA dependency to 22

### DIFF
--- a/helper-ktx/build.gradle.kts
+++ b/helper-ktx/build.gradle.kts
@@ -27,8 +27,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_22
+        targetCompatibility = JavaVersion.VERSION_22
     }
 
     kotlinOptions {

--- a/helper/build.gradle.kts
+++ b/helper/build.gradle.kts
@@ -34,8 +34,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_22
+        targetCompatibility = JavaVersion.VERSION_22
     }
 }
 


### PR DESCRIPTION
If the build machine has installed latest version of JDK:

Kotlin version used in the repo uses Java 22. But Java is not set to same version, causing "Inconsistent JVM-target compatibility detected for tasks 'compileJava' (21) and 'compileKotlin' (22)" error.
This updates the JVM target to resolve the issue.